### PR TITLE
osx: set NSApp activation policy if required

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ an additional dialog is spawned to confirm they want to overwrite the existing f
 Asks the user for a directory.
 
 # platform details
-* OSX: uses Cocoa's NSAlert/NSSavePanel/NSOpenPanel classes
+* OSX: uses Cocoa's NSAlert/NSSavePanel/NSOpenPanel/NSApp classes
+    * requires macOS 10.6+ for `NSApplicationActivationPolicyAccessory`
 * Win32: uses MessageBox/GetOpenFileName/GetSaveFileName (via package github.com/TheTitanrain/w32)
 * Linux: uses Gtk's MessageDialog/FileChooserDialog (via cgo; requires gtk3 development packages)
 

--- a/cocoa/dlg.m
+++ b/cocoa/dlg.m
@@ -5,6 +5,16 @@ void* NSStr(void* buf, int len) {
 	return (void*)[[NSString alloc] initWithBytes:buf length:len encoding:NSUTF8StringEncoding];
 }
 
+void checkActivationPolicy() {
+	NSApplicationActivationPolicy policy = [NSApp activationPolicy];
+	// prohibited NSApp will not show the panel at all.
+	// It probably means that this is not run in a GUI app, that would set the policy on its own,
+	// but in a terminal app - setting it to accessory will allow dialogs to show
+	if (policy == NSApplicationActivationPolicyProhibited) {
+		[NSApp setActivationPolicy:NSApplicationActivationPolicyAccessory];
+	}
+}
+
 void NSRelease(void* obj) {
 	[(NSObject*)obj release];
 }
@@ -52,6 +62,9 @@ DlgResult alertDlg(AlertDlgParams* params) {
 		[alert addButtonWithTitle:@"OK"];
 		break;
 	}
+
+	checkActivationPolicy();
+
 	self->result = [alert runModal] == NSAlertFirstButtonReturn ? DLG_OK : DLG_CANCEL;
 	return self->result;
 }
@@ -104,6 +117,9 @@ DlgResult fileDlg(FileDlgParams* params) {
 	if(self->params->filename != nil) {
 		[panel setNameFieldStringValue:[[NSString alloc] initWithUTF8String:self->params->filename]];
 	}
+
+	checkActivationPolicy();
+
 	return [panel runModal];
 }
 

--- a/example/simple/main.go
+++ b/example/simple/main.go
@@ -7,10 +7,6 @@ import (
 )
 
 func main() {
-	/* Note that spawning a dialog from a non-graphical app like this doesn't
-	** quite work properly in OSX. The dialog appears fine, and mouse
-	** interaction works but keypresses go straight through the dialog.
-	** I'm guessing it has something to do with not having a main loop? */
 	dialog.Message("%s", "Please select a file").Title("Hello world!").Info()
 	file, err := dialog.File().Title("Save As").Filter("All Files", "*").Save()
 	fmt.Println(file)


### PR DESCRIPTION
Currently, macOS dialogs don't work from the command-line, because the NSApp activation policy defaults to "Prohibited" in that context. This commit fixes that by setting the "Accessory" activation policy before opening a dialog, if (and only if) we are in the Prohibited state.

Closes #81. Fixes #15.